### PR TITLE
Fix missing target element for authentication modal

### DIFF
--- a/app/javascript/controllers/authentication_modal_controller.js
+++ b/app/javascript/controllers/authentication_modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["loginModal"]
+
+  open() {
+    this.loginModalTarget.showModal()
+  }
+
+  close() {
+    this.loginModalTarget.close()
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.loginModalTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
   </head>
 
   <body>
+    <%= render 'shared/navbar' %>
     <main >
       <%= yield %>
     </main>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,0 +1,97 @@
+<div class="navbar bg-base-100 shadow-sm flex justify-between" data-controller="authentication-modal">
+  <div class="navbar-start">
+    <%= link_to root_path, class: "btn btn-ghost text-xl" do %>
+      Osud Mama
+    <% end %>
+  </div>
+  
+  <div class="navbar-center hidden lg:flex">
+    <ul class="menu menu-horizontal px-1">
+      <li><%= link_to "Home", root_path %></li>
+      <li><%= link_to "About", "#" %></li>
+      <li><%= link_to "Contact", "#" %></li>
+    </ul>
+  </div>
+  
+  <div class="navbar-end">
+    <% if user_signed_in? %>
+      <div class="dropdown dropdown-end">
+        <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
+          <div class="w-10 rounded-full">
+            <div class="avatar placeholder">
+              <div class="bg-neutral text-neutral-content rounded-full w-10">
+                <span class="text-xs"><%= current_user.email.first.upcase %></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
+          <li><%= link_to "Profile", edit_user_registration_path %></li>
+          <li><%= link_to "Settings", "#" %></li>
+          <li><%= link_to "Logout", destroy_user_session_path, method: :delete %></li>
+        </ul>
+      </div>
+    <% else %>
+      <button class="btn btn-primary" data-action="click->authentication-modal#open">
+        Sign In
+      </button>
+    <% end %>
+  </div>
+
+  <!-- Authentication Modal -->
+  <dialog class="modal" data-authentication-modal-target="loginModal" data-action="click->authentication-modal#closeOnBackdrop">
+    <div class="modal-box">
+      <form method="dialog">
+        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" data-action="click->authentication-modal#close">✕</button>
+      </form>
+      
+      <h3 class="font-bold text-lg mb-4">Sign In to Your Account</h3>
+      
+      <%= form_for(:user, url: session_path(:user), html: { class: "space-y-4", data: { turbo: false } }) do |f| %>
+        <div class="form-control">
+          <%= f.label :email, class: "label" %>
+          <span class="label-text">Email</span>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", 
+                            class: "input input-bordered w-full", 
+                            placeholder: "your.email@example.com" %>
+        </div>
+
+        <div class="form-control">
+          <%= f.label :password, class: "label" %>
+          <span class="label-text">Password</span>
+          <%= f.password_field :password, autocomplete: "current-password", 
+                              class: "input input-bordered w-full", 
+                              placeholder: "Enter your password" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="form-control">
+            <label class="label cursor-pointer justify-start">
+              <%= f.check_box :remember_me, class: "checkbox checkbox-primary" %>
+              <span class="label-text ml-2">Remember me</span>
+            </label>
+          </div>
+        <% end %>
+
+        <div class="form-control mt-6">
+          <%= f.submit "Sign In", class: "btn btn-primary w-full" %>
+        </div>
+      <% end %>
+
+      <div class="divider">OR</div>
+      
+      <div class="text-center">
+        <p class="text-sm">
+          Don't have an account? 
+          <%= link_to "Sign up", new_user_registration_path, class: "link link-primary" %>
+        </p>
+        
+        <% if devise_mapping.recoverable? %>
+          <p class="text-sm mt-2">
+            <%= link_to "Forgot your password?", new_user_password_path, class: "link link-secondary" %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+  </dialog>
+</div>


### PR DESCRIPTION
Implement authentication modal with Stimulus.js to fix "Missing target element 'loginModal'" error.

The error occurred because the `authentication-modal` Stimulus controller was attempting to access a `loginModal` target that was not present in the DOM, and the controller itself was undefined. This PR adds the necessary Stimulus controller and HTML structure for a functional sign-in modal, integrated into the application navbar.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c03fcf9-98b5-408e-8f39-123bb2ce9767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c03fcf9-98b5-408e-8f39-123bb2ce9767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

